### PR TITLE
refactor using crypto::CryptoProvider from tendermint-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +350,9 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytesize"
@@ -390,7 +399,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi",
 ]
@@ -409,6 +418,12 @@ checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
  "generic-array 0.14.6",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "constant_time_eq"
@@ -460,6 +475,18 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array 0.14.6",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -515,6 +542,15 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -599,6 +635,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53aff6fdc1b181225acdcb5b14c47106726fd8e486707315b1b138baed68ee31"
 
 [[package]]
+name = "ecdsa"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1826508d57f3140a2e8e3c307b19915a266c92a1b8c2f6bb54e29e5d72a394ae"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,10 +670,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "elastic-array"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d63720ea2bc2e1b79f7aa044d9dc0b825f9ccb6930b32120f8fb9e873aa84bc"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "digest 0.10.3",
+ "ff",
+ "generic-array 0.14.6",
+ "group",
+ "rand_core 0.6.3",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "env_logger"
@@ -647,10 +720,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.3",
+ "subtle",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -672,6 +765,16 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flex-error"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
+dependencies = [
+ "eyre",
+ "paste",
 ]
 
 [[package]]
@@ -836,6 +939,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [
@@ -1011,7 +1140,17 @@ dependencies = [
  "near-primitives 0.12.0",
  "near-primitives-wasm",
  "sha2 0.10.2",
+ "tendermint",
  "tokio",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1033,6 +1172,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2573d3fd3e4cc741affc9b5ce1a8ce36cf29f09f80f36da4309d0ae6d7854"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -1290,6 +1441,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-std",
+ "tendermint",
 ]
 
 [[package]]
@@ -1321,6 +1473,7 @@ dependencies = [
  "near-primitives-wasm",
  "no-std-compat",
  "sha2 0.10.2",
+ "tendermint",
 ]
 
 [[package]]
@@ -1417,14 +1570,19 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "bs58",
+ "digest 0.10.3",
+ "ed25519",
+ "k256",
  "near-crypto 0.12.0",
  "near-primitives 0.12.0",
  "serde",
  "serde_json",
  "sha2 0.10.2",
+ "signature",
  "sp-core",
  "sp-io",
  "sp-std",
+ "tendermint",
 ]
 
 [[package]]
@@ -1590,6 +1748,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,6 +1819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1800,6 +1978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
 name = "pbkdf2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +2076,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -2061,6 +2278,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "rfc6979"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+dependencies = [
+ "crypto-bigint",
+ "hmac 0.12.1",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2423,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.6",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secp256k1"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2517,17 @@ dependencies = [
  "itoa 1.0.3",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2338,6 +2599,10 @@ name = "signature"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
+dependencies = [
+ "digest 0.10.3",
+ "rand_core 0.6.3",
+]
 
 [[package]]
 name = "slab"
@@ -2686,6 +2951,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2987,53 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tendermint"
+version = "0.25.0"
+source = "git+https://github.com/blasrodri/tendermint-rs?rev=8048e4de023cef94b59f3d526e24d612a88dd27b#8048e4de023cef94b59f3d526e24d612a88dd27b"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "digest 0.10.3",
+ "ed25519",
+ "ed25519-dalek",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.9.9",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto",
+ "time 0.3.16",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.25.0"
+source = "git+https://github.com/blasrodri/tendermint-rs?rev=8048e4de023cef94b59f3d526e24d612a88dd27b#8048e4de023cef94b59f3d526e24d612a88dd27b"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time 0.3.16",
+]
 
 [[package]]
 name = "termcolor"
@@ -2761,6 +3082,34 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+dependencies = [
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,3 +16,6 @@ near-primitives-wasm = {path = "../near-primitives-wasm"}
 near-lite-relayer = {path = "../near-lite-relayer"}
 tokio = { version = "1.17.0", features = ["full"] }
 sha2 = { version = "0.10.2"}
+
+# tendermint
+tendermint = { git = "https://github.com/blasrodri/tendermint-rs", rev = "8048e4de023cef94b59f3d526e24d612a88dd27b"}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -6,9 +6,20 @@ use alloc::collections::BTreeMap;
 use near_lite_client::{
 	CryptoHash, LightClientBlockView, NearLiteClientTrait, TrustedCheckpoint, ValidatorStakeView,
 };
-use near_primitives_wasm::HostFunctions;
+use near_primitives_wasm::{
+	host_functions::{NearSha256, NearSignatureVerifier, NearSigner},
+	HostFunctions,
+};
+use tendermint::crypto::CryptoProvider;
 
 pub struct NearHostFunctions;
+
+impl CryptoProvider for NearHostFunctions {
+	type Sha256 = NearSha256;
+
+	type EcdsaSecp256k1Signer = NearSigner<Self::Sha256>;
+	type EcdsaSecp256k1Verifier = NearSignatureVerifier<Self::Sha256>;
+}
 
 impl HostFunctions for NearHostFunctions {
 	fn sha256(data: &[u8]) -> [u8; 32] {

--- a/near-lite-client/Cargo.toml
+++ b/near-lite-client/Cargo.toml
@@ -15,6 +15,10 @@ near-primitives-wasm = {path = "../near-primitives-wasm", default-features = fal
 near-merkle-proofs = { path = "../near-merkle-proofs", default-features = false }
 sha2 = { version = "0.10.2", default-features = false }
 
+# tendermint
+tendermint = { git = "https://github.com/blasrodri/tendermint-rs", rev = "8048e4de023cef94b59f3d526e24d612a88dd27b"}
+
+
 
 [dev-dependencies]
 bs58 = "0.4.0"

--- a/near-lite-client/src/block_validation.rs
+++ b/near-lite-client/src/block_validation.rs
@@ -4,9 +4,7 @@ use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 use crate::{error::NearLiteClientError, LiteClientResult};
 
-use near_primitives_wasm::{
-	ApprovalInner, CryptoHash, LightClientBlockView, ValidatorStakeView,
-};
+use near_primitives_wasm::{ApprovalInner, CryptoHash, LightClientBlockView, ValidatorStakeView};
 
 use borsh::BorshSerialize;
 

--- a/near-lite-client/src/lib.rs
+++ b/near-lite-client/src/lib.rs
@@ -32,7 +32,7 @@ mod verifier;
 
 pub use checkpoint::TrustedCheckpoint;
 pub use near_primitives_wasm::{
-	CryptoHash, LightClientBlockView, MerklePath, OutcomeProof, Signature, ValidatorStakeView,
+	CryptoHash, LightClientBlockView, MerklePath, NearSignature, OutcomeProof, ValidatorStakeView,
 };
 pub use verifier::{validate_head, validate_transaction, validate_transactions};
 
@@ -43,7 +43,7 @@ pub type LiteClientResult<T> = Result<T, NearLiteClientError>;
 pub mod prelude {
 	pub use super::{
 		validate_head, validate_transaction, validate_transactions, CryptoHash,
-		LightClientBlockView, MerklePath, NearLiteClientTrait, OutcomeProof, Signature,
+		LightClientBlockView, MerklePath, NearLiteClientTrait, NearSignature, OutcomeProof,
 		TrustedCheckpoint, ValidatorStakeView,
 	};
 }

--- a/near-lite-client/src/test_utils.rs
+++ b/near-lite-client/src/test_utils.rs
@@ -1,7 +1,18 @@
-use near_primitives_wasm::HostFunctions;
+use near_primitives_wasm::{
+	host_functions::{NearSha256, NearSignatureVerifier, NearSigner},
+	HostFunctions,
+};
+use tendermint::crypto::CryptoProvider;
 
 #[cfg(test)]
 pub struct MockedHostFunctions;
+
+impl CryptoProvider for MockedHostFunctions {
+	type Sha256 = NearSha256;
+
+	type EcdsaSecp256k1Signer = NearSigner<Self::Sha256>;
+	type EcdsaSecp256k1Verifier = NearSignatureVerifier<Self::Sha256>;
+}
 
 #[cfg(any(test))]
 impl HostFunctions for MockedHostFunctions {
@@ -11,7 +22,7 @@ impl HostFunctions for MockedHostFunctions {
 	}
 
 	fn verify(
-		signature: near_primitives_wasm::Signature,
+		signature: near_primitives_wasm::NearSignature,
 		data: impl AsRef<[u8]>,
 		public_key: near_primitives_wasm::PublicKey,
 	) -> bool {

--- a/near-merkle-proofs/Cargo.toml
+++ b/near-merkle-proofs/Cargo.toml
@@ -13,6 +13,9 @@ core2 = {version = "0.3.2", default-features = false }
 
 near-primitives-wasm = {path = "../near-primitives-wasm", default-features = false }
 
+# tendermint
+tendermint = { git = "https://github.com/blasrodri/tendermint-rs", rev = "8048e4de023cef94b59f3d526e24d612a88dd27b"}
+
 [dev-dependencies]
 sha2 = "0.10.2"
 hex = "0.4"

--- a/near-merkle-proofs/src/lib.rs
+++ b/near-merkle-proofs/src/lib.rs
@@ -304,7 +304,11 @@ fn hash_borsh<T: BorshSerialize, HF: HostFunctions>(items: &(T, T)) -> CryptoHas
 mod tests {
 	use borsh::BorshDeserialize;
 	use near_primitives::merkle::{compute_root_from_path_and_item, merklize};
-	use near_primitives_wasm::MerklePathItem;
+	use near_primitives_wasm::{
+		host_functions::{NearSha256, NearSignatureVerifier, NearSigner},
+		MerklePathItem,
+	};
+	use tendermint::crypto::CryptoProvider;
 
 	use super::*;
 
@@ -330,19 +334,14 @@ mod tests {
 	}
 
 	struct MockedHostFunctions;
-	impl HostFunctions for MockedHostFunctions {
-		fn sha256(data: &[u8]) -> [u8; 32] {
-			use sha2::Digest;
-			sha2::Sha256::digest(data).try_into().unwrap()
-		}
 
-		fn verify(
-			_signature: near_primitives_wasm::Signature,
-			_data: impl AsRef<[u8]>,
-			_public_key: near_primitives_wasm::PublicKey,
-		) -> bool {
-			todo!()
-		}
+	impl HostFunctions for MockedHostFunctions {}
+
+	impl CryptoProvider for MockedHostFunctions {
+		type Sha256 = NearSha256;
+
+		type EcdsaSecp256k1Signer = NearSigner<Self::Sha256>;
+		type EcdsaSecp256k1Verifier = NearSignatureVerifier<Self::Sha256>;
 	}
 
 	#[test]

--- a/near-merkle-proofs/src/state_proof.rs
+++ b/near-merkle-proofs/src/state_proof.rs
@@ -280,8 +280,18 @@ mod tests {
 	use core::str::FromStr;
 
 	use near_primitives::hash::CryptoHash as NearCryptoHash;
+	use near_primitives_wasm::host_functions::{NearSha256, NearSignatureVerifier, NearSigner};
+	use tendermint::crypto::CryptoProvider;
 
 	struct MockedHostFunctions;
+
+	impl CryptoProvider for MockedHostFunctions {
+		type Sha256 = NearSha256;
+
+		type EcdsaSecp256k1Signer = NearSigner<Self::Sha256>;
+		type EcdsaSecp256k1Verifier = NearSignatureVerifier<Self::Sha256>;
+	}
+
 	impl HostFunctions for MockedHostFunctions {
 		fn sha256(data: &[u8]) -> [u8; 32] {
 			use sha2::Digest;
@@ -289,7 +299,7 @@ mod tests {
 		}
 
 		fn verify(
-			signature: near_primitives_wasm::Signature,
+			signature: near_primitives_wasm::NearSignature,
 			data: impl AsRef<[u8]>,
 			public_key: near_primitives_wasm::PublicKey,
 		) -> bool {

--- a/near-primitives-wasm/Cargo.toml
+++ b/near-primitives-wasm/Cargo.toml
@@ -11,6 +11,12 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 sha2 = {version = "0.10.2", default-features = false }
+tendermint = { git = "https://github.com/blasrodri/tendermint-rs", rev = "8048e4de023cef94b59f3d526e24d612a88dd27b"}
+k256 = { version = "0.11", default-features = false, features = ["ecdsa", "sha256"] }
+digest = { version = "0.10", default-features = false }
+signature = { version = "1", default-features = false }
+ed25519 = { version = "1.3", default-features = false }
+
 
 
 

--- a/near-primitives-wasm/src/host_functions.rs
+++ b/near-primitives-wasm/src/host_functions.rs
@@ -1,9 +1,123 @@
-use crate::{PublicKey, Signature};
+use crate::{NearSignature, PublicKey};
+use digest::{typenum::U32, Digest, FixedOutput};
+use k256::ecdsa::{SigningKey, VerifyingKey};
+use tendermint::crypto::CryptoProvider;
 
-pub trait HostFunctions {
-	fn sha256(data: &[u8]) -> [u8; 32];
+pub trait HostFunctions: CryptoProvider {
+	// type CP: CryptoProvider;
+	fn sha256(data: &[u8]) -> [u8; 32] {
+		let mut hasher = <Self as CryptoProvider>::Sha256::new();
+		hasher.update(data);
+		let result = hasher.finalize().try_into().unwrap();
+		result
+	}
 
-	fn verify(signature: Signature, data: impl AsRef<[u8]>, public_key: PublicKey) -> bool {
+	fn verify(signature: NearSignature, data: impl AsRef<[u8]>, public_key: PublicKey) -> bool {
 		signature.verify(data, public_key)
 	}
 }
+
+/// A draft for an imlpementation of the HostFunctionManager for a specific chain (i.e. Polkadot/Near)
+/// that uses the [`CryptoProvider`] trait
+use core::marker::PhantomData;
+use signature::{DigestSigner, DigestVerifier, Signer, Verifier};
+
+struct NearHostFunctionsManager;
+
+#[derive(Debug, Default)]
+pub struct NearSha256(sha2::Sha256);
+
+#[derive(Debug)]
+
+pub struct NearSigner<D> {
+	inner: SigningKey,
+	_d: PhantomData<D>,
+}
+#[derive(Debug)]
+pub struct NearSignatureVerifier<D> {
+	inner: VerifyingKey,
+	_d: PhantomData<D>,
+}
+
+impl<D: Digest + FixedOutput<OutputSize = U32>> NearSignatureVerifier<D> {
+	fn from_bytes(public_key: &[u8]) -> Result<Self, ed25519::Error> {
+		Ok(Self { inner: VerifyingKey::from_sec1_bytes(public_key)?, _d: PhantomData::default() })
+	}
+}
+
+impl<D: Digest + FixedOutput<OutputSize = U32>, S: signature::Signature> DigestVerifier<D, S>
+	for NearSignatureVerifier<D>
+where
+	VerifyingKey: DigestVerifier<D, S>,
+{
+	fn verify_digest(&self, digest: D, signature: &S) -> Result<(), ed25519::Error> {
+		self.inner.verify_digest(digest, signature)
+	}
+}
+
+impl<S: signature::PrehashSignature, D: Digest + FixedOutput<OutputSize = U32>> Verifier<S>
+	for NearSignatureVerifier<D>
+where
+	VerifyingKey: DigestVerifier<D, S>,
+{
+	fn verify(&self, msg: &[u8], signature: &S) -> Result<(), ed25519::Error> {
+		let mut hasher = D::new();
+		Digest::update(&mut hasher, msg);
+		self.verify_digest(hasher, signature)
+	}
+}
+
+impl digest::OutputSizeUser for NearSha256 {
+	type OutputSize = U32;
+}
+
+impl digest::HashMarker for NearSha256 {}
+
+impl digest::Update for NearSha256 {
+	fn update(&mut self, data: &[u8]) {
+		Digest::update(&mut self.0, data)
+	}
+}
+
+impl FixedOutput for NearSha256 {
+	fn finalize_into(self, out: &mut digest::Output<Self>) {
+		*out = self.0.finalize();
+	}
+}
+
+impl<D: Digest, S: signature::Signature> Signer<S> for NearSigner<D>
+where
+	SigningKey: DigestSigner<D, S>,
+{
+	fn try_sign(&self, msg: &[u8]) -> Result<S, ed25519::Error> {
+		let mut hasher = D::new();
+		Digest::update(&mut hasher, msg);
+		self.inner.try_sign_digest(hasher)
+	}
+}
+
+impl CryptoProvider for NearHostFunctionsManager {
+	type Sha256 = NearSha256;
+
+	type EcdsaSecp256k1Signer = NearSigner<Self::Sha256>;
+	type EcdsaSecp256k1Verifier = NearSignatureVerifier<Self::Sha256>;
+}
+
+// impl NearHostFunctions for NearHostFunctionsManager {
+// 	fn sha2_256(preimage: &[u8]) -> [u8; 32] {
+// 		let mut hasher = <Self as CryptoProvider>::Sha256::new();
+// 		hasher.update(preimage);
+// 		let result = hasher.finalize().try_into().unwrap();
+// 		result
+// 	}
+// 	fn ed25519_verify(sig: &[u8], msg: &[u8], pub_key: &[u8]) -> Result<(), ()> {
+// 		let verifier =
+// 			<<Self as CryptoProvider>::EcdsaSecp256k1Verifier>::from_bytes(pub_key).unwrap();
+// 		let signature = k256::ecdsa::Signature::from_der(sig).unwrap();
+// 		Ok(verifier.verify(msg, &signature).unwrap())
+// 	}
+
+// 	fn secp256k1_verify(_sig: &[u8], _message: &[u8], _public: &[u8]) -> Result<(), ()> {
+// 		unimplemented!()
+// 	}
+// }


### PR DESCRIPTION
A draft PR that displays how a light client would work if it would integrate the crypto::CryptoProvider defined in `tendermint-rs`